### PR TITLE
overwrite pkg links on install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
       - run: ./pkgm.ts i pkgx.sh/brewkit
       - run: /usr/local/bin/bk --help
 
+      - run: rm /usr/local/bin/bk
+      - run: test ! -f /usr/local/bin/bk
+      - run: ./pkgm.ts i pkgx.sh/brewkit
+      - run: /usr/local/bin/bk --help
+
       - run: |
           if [[ "$(/usr/local/bin/pkgx --version)" != "pkgx 2"* ]]; then
             exit 1

--- a/pkgm.ts
+++ b/pkgm.ts
@@ -104,18 +104,6 @@ async function install(args: string[]) {
   // deno-lint-ignore no-explicit-any
   const pkg_prefixes = json.pkgs.map((x: any) => `${x.project}/v${x.version}`);
 
-  const to_install = [];
-  for (const prefix of pkg_prefixes) {
-    if (!existsSync(join("/usr/local/pkgs", prefix))) {
-      to_install.push(prefix);
-    }
-  }
-
-  if (to_install.length === 0) {
-    console.error("pkgs already installed");
-    Deno.exit(0);
-  }
-
   const self = fromFileUrl(import.meta.url);
   const pkgx_dir = Deno.env.get("PKGX_DIR") || `${Deno.env.get("HOME")}/.pkgx`;
   const needs_sudo = Deno.uid() != 0;
@@ -133,7 +121,7 @@ async function install(args: string[]) {
     "sudo-install",
     pkgx_dir,
     runtime_env,
-    ...to_install,
+    ...pkg_prefixes,
   ];
   const cmd = needs_sudo ? "/usr/bin/sudo" : args.shift()!;
   status = await new Deno.Command(cmd, { args, env, clearEnv: true })
@@ -209,12 +197,16 @@ async function mirror_directory(dst: string, src: string, prefix: string) {
         await processEntry(entrySourcePath, entryTargetPath);
       }
     } else if (fileInfo.isFile) {
+      // Remove the target file if it exists
+      if (existsSync(targetPath)) {
+        await Deno.remove(targetPath);
+      }
       // Create a hard link for files
       await Deno.link(sourcePath, targetPath);
     } else if (fileInfo.isSymlink) {
       // Recreate symlink in the target directory
       const linkTarget = await Deno.readLink(sourcePath);
-      await Deno.symlink(linkTarget, targetPath);
+      symlink_with_overwrite(linkTarget, targetPath);
     } else {
       throw new Error(`unsupported file type at: ${sourcePath}`);
     }
@@ -247,7 +239,7 @@ async function symlink(src: string, dst: string) {
       if (existsSync(targetPath)) {
         await Deno.remove(targetPath);
       }
-      await Deno.symlink(sourcePath, targetPath);
+      symlink_with_overwrite(sourcePath, targetPath);
     }
   }
 }
@@ -282,7 +274,7 @@ async function create_v_symlinks(prefix: string) {
   }
 
   for (const [key, value] of Object.entries(major_versions)) {
-    await Deno.symlink(`v${semver.format(value)}`, join(shelf, `v${key}`));
+    symlink_with_overwrite(`v${semver.format(value)}`, join(shelf, `v${key}`));
   }
 }
 
@@ -299,4 +291,11 @@ function expand_runtime_env(
     expanded[project] = expanded_env;
   }
   return JSON.stringify(expanded);
+}
+
+function symlink_with_overwrite(src: string, dst: string) {
+  if (existsSync(dst)) {
+    Deno.removeSync(dst);
+  }
+  Deno.symlinkSync(src, dst);
 }


### PR DESCRIPTION
closes #27

this should be fine. we just remove destinations before creating them. this makes `install` work even in the presence of existing installations (which, again, should be just fine).

this could be gated behind a `--force` flag if required.