### PR TITLE
add lazy shims back in

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ $ pkgm local-install git
 # ^^ installs git to ~/.local. ie. you get ~/.local/bin/git
 # `pkgm li git` is easier to type and remember
 
+$ pkgm shim git
+# ^^ creates a shim for git in ~/.local/bin
+# these shims mimic the pkgx v1 lazy-loading shims, and are desirable for
+# certain types of self-healing and dev-setup containers, among other things
+
 $ pkgm list
 # ^^ lists what is installed
 


### PR DESCRIPTION
they have a legitimate use case for docker

see discussion beginning: https://discord.com/channels/1175095878818742316/1175095879435296820/1345155016629157888

@mxcl: i think this should follow the install/local-install split, but duplicating and de-duplicating all the sudo code felt too much for a proof-of-concept. if we like this, I can do it, however.