### PR TITLE
`pkgm outdated`

### DIFF
--- a/pkgm.ts
+++ b/pkgm.ts
@@ -87,6 +87,7 @@ if (parsedArgs.help) {
     case "up":
     case "update":
     case "pin":
+      break;
     case "outdated":
       await outdated();
       break;


### PR DESCRIPTION
Really we need to record what constraint the user requested when installing as well as what packages were explicitly installed in order to do a better job here.

Currently we assume any ^x that is newer counts as outdated provided it is not a package that is a dependency with a tighter constraint range.

This also ties into how we handle multiple installs, which currently we do, eg. you can have openssl^1 and openssl^3 both installed though this works by luck rather than by design. If you have both then we need to state that both ^1 and ^3 are outdated, this naive implementation will actually error currently for this case.

This implementation also misses new major versions which you will commonly want to upgrade to, eg. a `git^3` is released, because we don’t want to tell the user eg. `openssl^1` is outdated when it fact it is a dependency. This can probably be fixed without a data store but I didn't do it yet.