### PR TITLE
`sudo pkgm install` not `pkgm local-install`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,32 +35,29 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pkgxdev/setup@v3
 
-      - run: |
-          if [[ "$(/usr/local/bin/pkgx --version)" != "pkgx 2"* ]]; then
-            exit 1
-          fi
-
       - run: ./pkgm.ts i git
-      - run: /usr/local/bin/git --version
-      - run: ./pkgm.ts ls | grep /usr/local/pkgs/git-scm.org
+      - run: ~/.local/bin/git --version
+      - run: "! test -f /usr/local/bin/git"
+      - run: ./pkgm.ts ls | grep .local/pkgs/git-scm.org
       - run: ./pkgm.ts rm git
-      - run: test ! -f /usr/local/bin/git
+      - run: test ! -f ~/.local/bin/git
 
       - run: ./pkgm.ts i pkgx.sh/brewkit
-      - run: /usr/local/bin/bk --help
+      - run: ~/.local/bin/bk --help
 
       # check repeats work
-      - run: rm /usr/local/bin/bk
+      - run: rm ~/.local/bin/bk
       - run: test ! -f /usr/local/bin/bk
       - run: ./pkgm.ts i pkgx.sh/brewkit
-      - run: /usr/local/bin/bk --help
+      - run: ~/.local/bin/bk --help
 
-      - run: ./pkgm.ts li gum
+      - run: ./pkgm.ts i gum
       - run: ~/.local/bin/gum --version
 
+      # test a thing with deps
       # https://github.com/pkgxdev/pkgm/issues/24
       - run: ./pkgm.ts i curl
-      - run: /usr/local/bin/curl -L pkgx.sh
+      - run: ~/.local/bin/curl -L pkgx.sh
 
       - run: ./pkgm.ts shim semverator
       - run: ~/.local/bin/semverator validate 1.0.0

--- a/README.md
+++ b/README.md
@@ -16,16 +16,15 @@ Install `pkgx` packages to `/usr/local`.
 
 ```sh
 $ pkgm install git
-# ^^ installs latest git
+# ^^ installs latest git to ~/.local. ie. you get ~/.local/bin/git
 
 $ pkgm install git@2.41
 # ^^ installs git^2.41 or switches out the installed git to 2.41
 
 $ pkgm uninstall git
 
-$ pkgm local-install git
-# ^^ installs git to ~/.local. ie. you get ~/.local/bin/git
-# `pkgm li git` is easier to type and remember
+$ sudo pkgm install git
+# ^^ installs git to /usr/local. ie. you get /usr/local/bin/git
 
 $ pkgm shim git
 # ^^ creates a shim for git in ~/.local/bin
@@ -40,7 +39,10 @@ $ pkgm outdated
 # ^^ lists outdated installations
 
 $ pkgm update
-# ^^ updates installed packages to latest versions
+# ^^ updates ~/.local packages to latest versions
+
+$ sudo pkgm update
+# ^^ updates /usr/local packages to latest versions
 
 $ pkgm pin git
 # ^^ prevents the installed git from being updated


### PR DESCRIPTION
Require `sudo` in order to perform write operations on /usr/local.

Commands that do not require write will still function against both possible prefixes.