### PR TITLE
Fall back to making a regular copy if hard linking fails

### DIFF
--- a/pkgm.ts
+++ b/pkgm.ts
@@ -372,7 +372,10 @@ async function mirror_directory(dst: string, src: string, prefix: string) {
         await Deno.link(sourcePath, targetPath);
       } catch {
         if (!warned_copy_fallback) {
-          console.warn("%c! hardlinking failed (possibly cross-device?), falling back to file copy", "color:yellow");
+          console.warn(
+            "%c! hardlinking failed (possibly cross-device?), falling back to file copy",
+            "color:yellow",
+          );
           warned_copy_fallback = true;
         }
         await Deno.copyFile(sourcePath, targetPath);


### PR DESCRIPTION
This fixes using `pkgm` on Linux distributions where the home directory is setup on a different volume than `/usr/local`. For example, this is the case on a default installation of Fedora.

Together with [this other PR](https://github.com/pkgxdev/pkgx/pull/1219) in pkgx, this fixes using `sudo pkgm install <package>` on Linux to install packages in `/usr/local/bin`. See full [discussion](https://github.com/pkgxdev/pkgx/issues/1218) for more information.