### PR TITLE
fix: use SemVer for pkgx version comparison

### DIFF
--- a/pkgm.ts
+++ b/pkgm.ts
@@ -518,8 +518,8 @@ function get_pkgx() {
     if (existsSync(pkgx)) {
       const out = new Deno.Command(pkgx, { args: ["--version"] }).outputSync();
       const stdout = new TextDecoder().decode(out.stdout);
-      const match = stdout.match(/^pkgx (\d+.\d+)/);
-      if (!match || parseFloat(match[1]) < 2.4) {
+      const match = stdout.match(/^pkgx (\d+\.\d+\.\d+)/);
+      if (!match || new SemVer(match[1]).lt(new SemVer("2.4.0"))) {
         Deno.exit(1);
       }
       return pkgx;


### PR DESCRIPTION
## Summary
- `parseFloat("2.10")` evaluates to `2.1`, causing `get_pkgx()` to silently reject pkgx 2.10.x as below the minimum version (2.4)
- All pkgm commands (`install`, `uninstall`, `shim`) silently fail with exit code 1 when pkgx >= 2.10.0 is installed
- Fixed by using the already-imported `SemVer` class for proper semantic version comparison
