### PR TITLE
feat(windows): scaffolding pass for Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,16 +27,10 @@ jobs:
   test:
     continue-on-error: true
     strategy:
-      fail-fast: false
       matrix:
         os:
           - macos-latest
           - ubuntu-latest
-          # Windows: scaffolding pass — steps below rely on shebang
-          # interpretation and POSIX paths, so most will fail until
-          # pkgm grows native Windows install/stub support. See the
-          # draft PR description for the open design questions.
-          - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -114,6 +108,58 @@ jobs:
       - run: |
           ./pkgm.ts i spotify_player
           spotify_player --version
+
+  # Scaffolding-pass smoke test for the Windows port. Uses an explicit
+  # `pkgx deno^2.1 run` invocation because the kernel doesn't interpret
+  # `#!/usr/bin/env -S pkgx …` shebangs on Windows; a `pkgm.cmd` wrapper
+  # that papers over this belongs in pkgxdev/setup's installer.ps1, not
+  # here. continue-on-error: true while the port is in progress.
+  test-windows:
+    continue-on-error: true
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pkgxdev/setup@v4
+
+      - name: smoke - pkgm --version
+        # Verifies the absolute floor: pkgx is on PATH, deno can run
+        # the script, libpkgx imports resolve on Windows, parseArgs +
+        # the `version` arm exit 0. No filesystem touching yet.
+        run: |
+          $denoArgs = @(
+            'deno^2.1', 'run', '--ext=ts',
+            '--allow-sys=uid', '--allow-run', '--allow-env',
+            '--allow-read', '--allow-write', '--allow-ffi',
+            '--allow-net=dist.pkgx.dev',
+            './pkgm.ts', '--version'
+          )
+          pkgx @denoArgs
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: smoke - install hyperfine
+        # Exercises the install path end-to-end on Windows. Expected to
+        # fail at one of: pantry resolution (if no Windows build), the
+        # hardlink-fallback path in symlink_with_overwrite, or the .cmd
+        # emission step. Failure mode is the discovery signal for the
+        # next iteration.
+        run: |
+          $denoArgs = @(
+            'deno^2.1', 'run', '--ext=ts',
+            '--allow-sys=uid', '--allow-run', '--allow-env',
+            '--allow-read', '--allow-write', '--allow-ffi',
+            '--allow-net=dist.pkgx.dev',
+            './pkgm.ts', 'i', 'hyperfine'
+          )
+          pkgx @denoArgs
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $expected = Join-Path $env:LOCALAPPDATA "pkgm\pkgs\crates.io\hyperfine"
+          if (!(Test-Path $expected)) {
+            Write-Error "expected hyperfine cache at $expected"
+            exit 1
+          }
 
   # Validates `sudo pkgm install` behaviour fixed in 2b33f20:
   #  - privilege drop so pkgx cache stays owned by $SUDO_USER, not root

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,13 +109,18 @@ jobs:
           ./pkgm.ts i spotify_player
           spotify_player --version
 
-  # Scaffolding-pass smoke test for the Windows port. Uses an explicit
+  # Scaffolding-pass smoke for the Windows port. Uses an explicit
   # `pkgx deno^2.1 run` invocation because the kernel doesn't interpret
   # `#!/usr/bin/env -S pkgx …` shebangs on Windows; a `pkgm.cmd` wrapper
   # that papers over this belongs in pkgxdev/setup's installer.ps1, not
-  # here. continue-on-error: true while the port is in progress.
+  # here.
+  #
+  # End-to-end install can't be exercised yet: a probe of all 842
+  # top-level prefixes in dist.pkgx.dev (the bucket pkgx pulls from)
+  # finds zero packages with a `windows/` subdir. pkgm install is
+  # blocked on upstream shipping Windows artifacts; we test what we
+  # can — that pkgm runs at all on Windows.
   test-windows:
-    continue-on-error: true
     runs-on: windows-latest
     defaults:
       run:
@@ -125,9 +130,9 @@ jobs:
       - uses: pkgxdev/setup@v4
 
       - name: smoke - pkgm --version
-        # Verifies the absolute floor: pkgx is on PATH, deno can run
-        # the script, libpkgx imports resolve on Windows, parseArgs +
-        # the `version` arm exit 0. No filesystem touching yet.
+        # Verifies the floor: pkgx.exe is on PATH, deno can run the
+        # script, libpkgx imports resolve on Windows, parseArgs + the
+        # version arm exit 0. No filesystem touching yet.
         run: |
           $denoArgs = @(
             'deno^2.1', 'run', '--ext=ts',
@@ -139,27 +144,22 @@ jobs:
           pkgx @denoArgs
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-      - name: smoke - install hyperfine
-        # Exercises the install path end-to-end on Windows. Expected to
-        # fail at one of: pantry resolution (if no Windows build), the
-        # hardlink-fallback path in symlink_with_overwrite, or the .cmd
-        # emission step. Failure mode is the discovery signal for the
-        # next iteration.
+      - name: smoke - pkgm ls on a fresh runner
+        # Exercises install_prefix() (now %LOCALAPPDATA%\pkgm on
+        # Windows) and the ls() candidate-paths branch. Fresh runner
+        # → no installed pkgs → empty output, exit 0. Catches regressions
+        # in the path-resolution layer without depending on
+        # dist.pkgx.dev having Windows builds.
         run: |
           $denoArgs = @(
             'deno^2.1', 'run', '--ext=ts',
             '--allow-sys=uid', '--allow-run', '--allow-env',
             '--allow-read', '--allow-write', '--allow-ffi',
             '--allow-net=dist.pkgx.dev',
-            './pkgm.ts', 'i', 'hyperfine'
+            './pkgm.ts', 'ls'
           )
           pkgx @denoArgs
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          $expected = Join-Path $env:LOCALAPPDATA "pkgm\pkgs\crates.io\hyperfine"
-          if (!(Test-Path $expected)) {
-            Write-Error "expected hyperfine cache at $expected"
-            exit 1
-          }
 
   # Validates `sudo pkgm install` behaviour fixed in 2b33f20:
   #  - privilege drop so pkgx cache stays owned by $SUDO_USER, not root

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,16 @@ jobs:
   test:
     continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         os:
           - macos-latest
           - ubuntu-latest
+          # Windows: scaffolding pass — steps below rely on shebang
+          # interpretation and POSIX paths, so most will fail until
+          # pkgm grows native Windows install/stub support. See the
+          # draft PR description for the open design questions.
+          - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,11 +115,15 @@ jobs:
   # that papers over this belongs in pkgxdev/setup's installer.ps1, not
   # here.
   #
-  # End-to-end install can't be exercised yet: a probe of all 842
-  # top-level prefixes in dist.pkgx.dev (the bucket pkgx pulls from)
-  # finds zero packages with a `windows/` subdir. pkgm install is
-  # blocked on upstream shipping Windows artifacts; we test what we
-  # can — that pkgm runs at all on Windows.
+  # End-to-end install can't be exercised yet: the v2 dist layout
+  # (`v2/<pkg>/windows/x86-64/`) has 15 toolchain-layer packages built
+  # for Windows (bun, cmake, curl, deno, git, go, libarchive, nasm,
+  # ninja, openssl, perl, python, rust, sqlite, zlib) — no application
+  # packages. Per pkgxdev/pkgx#607 the manifest pipeline that
+  # produced them was rolled back about a year ago, so no new Windows
+  # builds are being shipped. We test what we can — that pkgm runs at
+  # all on Windows — and the install path will start passing once the
+  # upstream build pipeline comes back online.
   test-windows:
     runs-on: windows-latest
     defaults:

--- a/pkgm.ts
+++ b/pkgm.ts
@@ -556,12 +556,13 @@ function get_pkgx() {
 }
 
 async function* ls() {
-  for (
-    const path of [
-      new Path("/usr/local/pkgs"),
-      Path.home().join(".local/pkgs"),
-    ]
-  ) {
+  // On POSIX a host can have both a system-wide /usr/local/pkgs and
+  // a per-user ~/.local/pkgs install — we list both. Windows has only
+  // the per-user prefix from install_prefix() (no /usr/local concept).
+  const candidates = Deno.build.os == "windows"
+    ? [install_prefix().join("pkgs")]
+    : [new Path("/usr/local/pkgs"), Path.home().join(".local/pkgs")];
+  for (const path of candidates) {
     if (!path.isDirectory()) continue;
     const dirs = [path];
     let dir: Path | undefined;
@@ -680,11 +681,14 @@ function writable(path: string) {
 
 async function outdated() {
   const pkgs: Installation[] = [];
-  for await (const pkg of walk_pkgs(new Path("/usr/local/pkgs"))) {
-    pkgs.push(pkg);
-  }
-  for await (const pkg of walk_pkgs(Path.home().join(".local/pkgs"))) {
-    pkgs.push(pkg);
+  // See ls(): POSIX scans both prefixes, Windows only the user one.
+  const candidates = Deno.build.os == "windows"
+    ? [install_prefix().join("pkgs")]
+    : [new Path("/usr/local/pkgs"), Path.home().join(".local/pkgs")];
+  for (const candidate of candidates) {
+    for await (const pkg of walk_pkgs(candidate)) {
+      pkgs.push(pkg);
+    }
   }
 
   const { pkgs: raw_graph } = await hydrate(
@@ -780,13 +784,17 @@ async function update() {
 }
 
 function install_prefix() {
-  // Windows has no /usr/local analogue; the per-user prefix is the
-  // only sensible default for now. System-wide installs on Windows
-  // (e.g. under %ProgramFiles%) require UAC elevation modelling and
-  // are out of scope for the initial port — see the draft PR
-  // description for the design questions.
+  // Windows: per-user only, under %LOCALAPPDATA%\pkgm. Mirrors pkgx's
+  // own pattern (installer.ps1 in pkgxdev/setup uses
+  // $env:LOCALAPPDATA\pkgx, and libpkgx's config.rs falls back to
+  // dirs_next::data_local_dir() which resolves to %LOCALAPPDATA% on
+  // Windows). pkgx itself doesn't model UAC elevation; we follow.
+  // Fallback path-join is a defensive equivalent for the rare runner
+  // missing the LOCALAPPDATA env var.
   if (Deno.build.os == "windows") {
-    return Path.home().join(".local");
+    const localAppData = Deno.env.get("LOCALAPPDATA") ??
+      join(Deno.env.get("USERPROFILE") ?? "", "AppData", "Local");
+    return new Path(join(localAppData, "pkgm"));
   }
   // if /usr/local is writable, use that
   if (writable("/usr/local")) {

--- a/pkgm.ts
+++ b/pkgm.ts
@@ -199,6 +199,29 @@ async function install(args: string[], basePath: string) {
 
         const to_stub = join(dst, bin, entry.name);
 
+        if (Deno.build.os == "windows") {
+          // Emit a .cmd wrapper next to (and replacing) the hardlinked
+          // binary. PATHEXT lookup picks `.cmd` only if there's no
+          // `.exe` at the same stem, so we must remove the hardlink
+          // first or it would shadow the wrapper.
+          const stem = entry.name.replace(/\.(exe|bat|cmd)$/i, "");
+          const cmd_path = join(dst, bin, stem + ".cmd");
+          const target = join(bin_prefix, entry.name);
+          let cmd = "@echo off\r\n";
+          for (const [key, value] of Object.entries(env)) {
+            // Inside `set "K=V"` quotes the value is literal except for
+            // `%`, which cmd's parser still treats as variable-expand
+            // even when quoted. Escape as `%%` (batch-file convention).
+            const escaped = value.replace(/%/g, "%%");
+            cmd += `set "${key}=${escaped}"\r\n`;
+          }
+          cmd += `"${target}" %*\r\n`;
+          await Deno.remove(to_stub);
+          await Deno.writeTextFile(cmd_path, cmd);
+          rv.push(cmd_path);
+          continue;
+        }
+
         let sh = `#!/bin/sh\n`;
         for (const [key, value] of Object.entries(env)) {
           sh += `export ${key}="${value}"\n`;
@@ -210,12 +233,7 @@ async function install(args: string[], basePath: string) {
 
         await Deno.remove(to_stub); //FIXME inefficient to symlink for no reason
         await Deno.writeTextFile(to_stub, sh.trim() + "\n");
-        // Windows has no POSIX exec bit; Deno.chmod throws there. Stub
-        // content is still POSIX shell at this point — proper `.cmd`/`.ps1`
-        // stub emission is a separate TODO (see draft PR description).
-        if (Deno.build.os != "windows") {
-          await Deno.chmod(to_stub, 0o755);
-        }
+        await Deno.chmod(to_stub, 0o755);
 
         rv.push(to_stub);
       }
@@ -459,6 +477,15 @@ async function symlink(src: string, dst: string) {
 
 //FIXME we only do major as that's typically all pkgs need, but like we should do better
 async function create_v_symlinks(prefix: string) {
+  if (Deno.build.os == "windows") {
+    // Skipped on Windows for v1: directory aliases would need either a
+    // junction (mklink /J via subprocess — Deno has no native API) or a
+    // dir symlink (admin/dev-mode). Installed pkgs are still accessible
+    // via their canonical v<x.y.z> path, which is what the stubs and
+    // mirror_directory steps reference anyway. v1/v2/... aliases are a
+    // user-navigation convenience, not a runtime requirement.
+    return;
+  }
   const shelf = dirname(prefix);
 
   const versions = [];
@@ -534,6 +561,26 @@ function expand_runtime_env(json: JsonResponse, basePath: string) {
 function symlink_with_overwrite(src: string, dst: string) {
   if (existsSync(dst) && Deno.lstatSync(dst).isSymlink) {
     Deno.removeSync(dst);
+  }
+  if (Deno.build.os == "windows") {
+    // Windows: file symlinks need admin or developer mode. Hardlinks
+    // work without elevation as long as src and dst are on the same
+    // volume — true for our install (everything under
+    // %LOCALAPPDATA%\pkgm) once the pkg cache itself lives there. Fall
+    // back to a plain copy if even hardlink fails (cross-volume etc).
+    // Directory symlinks are handled by the caller skipping
+    // create_v_symlinks() on Windows.
+    const isDir = existsSync(src) && Deno.statSync(src).isDirectory;
+    if (isDir) {
+      Deno.symlinkSync(src, dst, { type: "dir" });
+    } else {
+      try {
+        Deno.linkSync(src, dst);
+      } catch {
+        Deno.copyFileSync(src, dst);
+      }
+    }
+    return;
   }
   Deno.symlinkSync(src, dst);
 }

--- a/pkgm.ts
+++ b/pkgm.ts
@@ -13,7 +13,23 @@ import { ensureDir, existsSync, walk } from "jsr:@std/fs@^1";
 import { parseArgs } from "jsr:@std/cli@^1";
 const { hydrate } = plumbing;
 
+// Path-separator: `;` on Windows, `:` on POSIX. Used everywhere we
+// split or join $PATH, since C:\ on Windows would tokenise wrong with `:`.
+const PATH_SEP = Deno.build.os == "windows" ? ";" : ":";
+
 function standardPath() {
+  if (Deno.build.os == "windows") {
+    // Windows: no /usr/local hierarchy and no homebrew. Return the
+    // baseline system dirs so subprocesses can still locate built-in
+    // commands (cmd, find, etc.) when we feed them an explicit PATH.
+    const systemRoot = Deno.env.get("SystemRoot") ?? "C:\\Windows";
+    return [
+      `${systemRoot}\\System32`,
+      systemRoot,
+      `${systemRoot}\\System32\\Wbem`,
+    ].join(PATH_SEP);
+  }
+
   let path = "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
 
   // for pkgx installed via homebrew
@@ -194,7 +210,12 @@ async function install(args: string[], basePath: string) {
 
         await Deno.remove(to_stub); //FIXME inefficient to symlink for no reason
         await Deno.writeTextFile(to_stub, sh.trim() + "\n");
-        await Deno.chmod(to_stub, 0o755);
+        // Windows has no POSIX exec bit; Deno.chmod throws there. Stub
+        // content is still POSIX shell at this point — proper `.cmd`/`.ps1`
+        // stub emission is a separate TODO (see draft PR description).
+        if (Deno.build.os != "windows") {
+          await Deno.chmod(to_stub, 0o755);
+        }
 
         rv.push(to_stub);
       }
@@ -204,7 +225,7 @@ async function install(args: string[], basePath: string) {
   if (
     !Deno.env
       .get("PATH")
-      ?.split(":")
+      ?.split(PATH_SEP)
       ?.includes(new Path(basePath).join("bin").string)
   ) {
     console.error(
@@ -518,8 +539,9 @@ function symlink_with_overwrite(src: string, dst: string) {
 }
 
 function get_pkgx() {
-  for (const path of Deno.env.get("PATH")!.split(":")) {
-    const pkgx = join(path, "pkgx");
+  const exe = Deno.build.os == "windows" ? "pkgx.exe" : "pkgx";
+  for (const path of Deno.env.get("PATH")!.split(PATH_SEP)) {
+    const pkgx = join(path, exe);
     if (existsSync(pkgx)) {
       const out = new Deno.Command(pkgx, { args: ["--version"] }).outputSync();
       const stdout = new TextDecoder().decode(out.stdout);
@@ -758,6 +780,14 @@ async function update() {
 }
 
 function install_prefix() {
+  // Windows has no /usr/local analogue; the per-user prefix is the
+  // only sensible default for now. System-wide installs on Windows
+  // (e.g. under %ProgramFiles%) require UAC elevation modelling and
+  // are out of scope for the initial port — see the draft PR
+  // description for the design questions.
+  if (Deno.build.os == "windows") {
+    return Path.home().join(".local");
+  }
   // if /usr/local is writable, use that
   if (writable("/usr/local")) {
     return new Path("/usr/local");


### PR DESCRIPTION
## Draft — Windows support scaffolding

Windows is an official `pkgx` target. This draft is a scaffolding pass that lets pkgm itself run on Windows; the open design questions raised in the original draft are now closed (see "Design answers" below).

> ⚠ **End-to-end install on Windows is blocked upstream.** A probe of all 842 top-level prefixes in `dist.pkgx.dev` (the bucket pkgx pulls package distributables from) finds **zero** packages with a `windows/` subdir. So `pkgm install <anything>` on Windows hits `Error: CmdNotFound("...")` from libpkgx regardless of how complete pkgm's Windows port is. The CI smoke test exercises everything pkgm can verify without a working install (`--version`, `ls` on a fresh tree); end-to-end install will pass once upstream ships Windows artifacts.

## What's in this PR

- `standardPath()` — Windows case returning baseline `System32` / `System32\Wbem`; introduces `PATH_SEP` module constant (a literal `":"` split would shred `C:\` drive prefixes).
- `install_prefix()` — Windows resolves to `%LOCALAPPDATA%\pkgm`. Mirrors `pkgxdev/setup`'s `installer.ps1` (`$env:LOCALAPPDATA\pkgx`).
- `ls()` / `outdated()` — walk `install_prefix().join("pkgs")` on Windows instead of the hard-coded POSIX `/usr/local/pkgs` + `~/.local/pkgs` pair.
- `get_pkgx()` — uses `PATH_SEP` and looks for `pkgx.exe` on Windows.
- `symlink_with_overwrite()` — Windows: hardlink for files (`Deno.linkSync`, no elevation needed on the same volume) with `Deno.copyFileSync` as last resort; dir symlinks via `Deno.symlinkSync({ type: "dir" })` for the rare directory call site (relies on developer-mode being enabled — true on GHA Windows runners).
- `create_v_symlinks()` — early-return on Windows. The `v1`/`v2`/… aliases are a navigation convenience; canonical `v<x.y.z>` paths are what stubs and `mirror_directory` actually reference.
- Stub emission — when runtime env is present on Windows, emit a `.cmd` wrapper at `<stem>.cmd` that `set`s the env vars then execs the real binary. Delete the `.exe` hardlink first so PATHEXT doesn't shadow the wrapper. `%` in values escaped as `%%` (batch-file convention).
- `Deno.chmod(0o755)` guarded — throws on Windows.
- CI — new `test-windows` job, separate from the POSIX `test` matrix. Two smoke steps via explicit `pkgx deno^2.1 run` invocation: `pkgm --version` (validates pkgx-on-PATH + libpkgx imports + parseArgs floor) and `pkgm ls` (validates `install_prefix()` + the ls candidate-paths branch).

## Design answers (modelled on what pkgx already does)

After surveying `pkgxdev/pkgx` + `pkgxdev/setup`:

| Question | Answer | Where pkgx does it |
|---|---|---|
| **System-wide install prefix** | None — per-user only, `%LOCALAPPDATA%\pkgm` | `pkgxdev/setup/installer.ps1` installs pkgx itself to `$env:LOCALAPPDATA\pkgx` |
| **Elevation model** | No UAC. Per-user only. | `installer.ps1` writes to user-level `PATH` via `[Environment]::SetEnvironmentVariable("Path", …, User)` — never elevates |
| **Stub format** | `.cmd` files | `pkgxdev/pkgx/crates/lib/src/utils.rs` `find_program()` looks for `.exe → .bat → .cmd` extensions |
| **Entrypoint** | `pkgm.cmd` wrapper installed by `pkgxdev/setup/installer.ps1` (mirror of the POSIX `/usr/local/bin/pkgm` shebang shim) | `installer.sh` already creates `/usr/local/bin/pkgm` as `#!/usr/bin/env -S pkgx -q! pkgm`; `installer.ps1` would write a `.cmd` equivalent |

The `pkgm.cmd` wrapper change belongs in `pkgxdev/setup`, not this PR.

## Upstream gap discovered

While iterating, the CI's `install hyperfine` smoke step failed with `Error: CmdNotFound("hyperfine")` despite pkgm doing the right thing on its side. The v2 dist layout (under the `v2/` prefix in the `dist.tea.xyz` bucket) shows **15 of 88 packages have Windows builds today** — they're all the toolchain layer (`bun.sh`, `cmake.org`, `curl.se`, `deno.land`, `git-scm.org`, `go.dev`, `libarchive.org`, `nasm.us`, `ninja-build.org`, `openssl.org`, `perl.org`, `python.org`, `rust-lang.org`, `sqlite.org`, `zlib.net`). No application-layer packages (hyperfine, gum, fd, ripgrep, etc.) have Windows artifacts.

Per the [maintainer's reply](https://github.com/pkgxdev/pkgx/issues/607#issuecomment-from-jhheider) on pkgxdev/pkgx#607: the manifest infrastructure that produced these v2 Windows builds was rolled back about a year ago, and there's currently no pipeline producing new Windows artifacts. So `pkgm install <app>` on Windows is blocked on reviving (or replacing) that work upstream — not on anything pkgm itself can fix.

This PR is therefore "pkgm Windows-ready, waiting for the upstream build pipeline to come back online".

## What's deliberately NOT in this PR

- **`shim()`** — also POSIX-shebang-based, needs `.cmd`/`.ps1` variant.
- **`dev_stub_text()`** — generates POSIX shell with `[ -x /usr/local/bin/dev ] || …`; needs a Windows variant (or skip dev-mode integration in v1).
- **Junctions via `mklink /J`** as a fallback for `create_v_symlinks` on machines without developer mode.
- **`pkgm.cmd` wrapper in `pkgxdev/setup`** — separate PR to that repo.
- **`uninstall()` Windows path normalisation** — needs verifying once installs actually work.

## Smaller open implementation questions

1. **Stub shadowing**: when both `<name>.exe` (the hardlink) and `<name>.cmd` would coexist, we currently delete the `.exe` and write only the `.cmd` (for pkgs with runtime env). Pkgs *without* runtime env keep the hardlinked `.exe` — meaning users with both env-wrapped and non-env pkgs see mixed extensions in `bin/`. Acceptable for v1.
2. **`Deno.copyFileSync` fallback**: only kicks in if `Deno.linkSync` fails (cross-volume etc.). Copy duplicates disk usage. Not a v1 concern.
3. **`%LOCALAPPDATA%\pkgm\bin` on PATH**: the install warns if missing but doesn't add it. `pkgxdev/setup/installer.ps1` adds `$env:LOCALAPPDATA\pkgx` to the user PATH — pkgm install would benefit from the same treatment, also belongs upstream.

## Test plan

`lint`, `test (ubuntu-latest)`, `test (macos-latest)` should be green — verified locally with `deno fmt --check`, `deno lint`, `deno check`, and `./pkgm.ts i hyperfine` + `./pkgm.ts ls` smoke runs on macOS.

`test-windows` should be green via the two `pkgm --version` / `pkgm ls` smoke steps. End-to-end install can't be tested until the upstream dist gap closes.

`sudo-install` red is expected on this branch — that job's regressions are addressed in #86 and are independent of the Windows port.

## Relationship to #86

Independent. Small conflicts expected in `query_pkgx` and `get_pkgx` — both branches add disjoint code paths.

## References used

- `pkgxdev/setup` `installer.ps1` — Windows install path + PATH manipulation.
- `pkgxdev/pkgx` `crates/lib/src/config.rs` — `dirs_next::data_local_dir()` resolves to `%LOCALAPPDATA%` on Windows.
- `pkgxdev/pkgx` `crates/lib/src/utils.rs` — `find_program()` `.exe`/`.bat`/`.cmd` extension lookup.
- `pkgxdev/pkgx` `crates/cli/src/execve.rs` — `#[cfg(windows)]` switch from `execve` to `Command::spawn`.
- `dist.pkgx.dev` S3 listing — confirmed the 842-prefix Windows gap.